### PR TITLE
Fixes #23: produces more correct recommendations for initial sampling stage.

### DIFF
--- a/pybo/solvers/bayesopt.py
+++ b/pybo/solvers/bayesopt.py
@@ -123,6 +123,7 @@ def solve_bayesopt(f,
     # initialize the data.
     info['x'][:len(X)] = X
     info['y'][:len(Y)] = Y
+    info['xbest'][:len(Y)] = [X[np.argmax(Y[:i+1])] for i in xrange(len(Y))]
 
     for i in xrange(model.ndata, T):
         # get the next point to evaluate.


### PR DESCRIPTION
Modifies `solve_bayesopt` to sequentially recommend the best observed
in the initial stage since no model is initialized.

This could (maybe) be improved by using a model if one is given. However, this could blur the line between initial sampling and the model-based decision-making, so I didn't implement this here.
